### PR TITLE
AWS accounts with EC2-Classic support

### DIFF
--- a/modules/ec2-classic/ami.tf
+++ b/modules/ec2-classic/ami.tf
@@ -1,0 +1,7 @@
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  filter {
+    name = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20170721"]
+  }
+}

--- a/modules/ec2-classic/ec2.tf
+++ b/modules/ec2-classic/ec2.tf
@@ -1,0 +1,85 @@
+resource "aws_instance" "nginx_node" {
+  ami = "${data.aws_ami.ubuntu.id}"
+  instance_type = "${var.instance_type}"
+  associate_public_ip_address = true
+  subnet_id = "${aws_subnet.us-east-1a-public.id}"
+
+  key_name = "${aws_key_pair.deployer-key.key_name}"
+  security_groups = ["${aws_security_group.node_nginx.id}"] // node-nginx
+
+  tags {
+    Name = "${var.project_name} [demo]"
+    Description = "Created with aws-provisioner for ${var.project_name}"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "mkdir -p ~/provision"
+    ]
+  }
+
+  provisioner "file" {
+    source = "${path.module}/provision/"
+    destination = "/home/ubuntu/provision/"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "chmod +x /home/ubuntu/provision/*",
+      "/home/ubuntu/provision/install_ubuntu_build_essential.sh",
+      "/home/ubuntu/provision/install_nvm.sh",
+      "/home/ubuntu/provision/install_dummy_app.sh",
+      "/home/ubuntu/provision/install_nginx.sh",
+    ]
+  }
+
+  connection {
+    user = "ubuntu"
+    type = "ssh"
+    private_key = "${file("${var.private_key_path}")}"
+  }
+}
+
+resource "aws_vpc" "selected" {
+  cidr_block = "10.0.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support = true
+  tags {
+    Name = "${var.project_name}"
+  }
+}
+
+resource "aws_subnet" "us-east-1a-public" {
+  vpc_id = "${aws_vpc.selected.id}"
+  cidr_block = "10.0.1.0/25"
+  availability_zone = "us-east-1a"
+}
+
+resource "aws_internet_gateway" "main" {
+  vpc_id = "${aws_vpc.selected.id}"
+  tags {
+    Name = "${var.project_name}"
+  }
+}
+
+resource "aws_default_route_table" "r" {
+  default_route_table_id = "${aws_vpc.selected.default_route_table_id}"
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = "${aws_internet_gateway.main.id}"
+  }
+
+  tags {
+    Name = "${var.project_name}"
+  }
+
+}
+
+output "nginx_node.public_dns" {
+  value = "${aws_instance.nginx_node.public_dns}"
+}
+
+output "nginx_node.public_ip" {
+  value = "${aws_instance.nginx_node.public_ip}"
+}

--- a/modules/ec2-classic/key_pair.tf
+++ b/modules/ec2-classic/key_pair.tf
@@ -1,0 +1,4 @@
+resource "aws_key_pair" "deployer-key" {
+  key_name = "${var.project_id}-key"
+  public_key = "${var.public_key}"
+}

--- a/modules/ec2-classic/main.tf
+++ b/modules/ec2-classic/main.tf
@@ -1,0 +1,22 @@
+provider "aws" {
+  region = "${var.region}"
+  profile = "${var.profile}"
+}
+
+variable "region" {}
+variable "profile" {}
+
+variable "project_name" {
+  default = "Hello World"
+}
+
+variable "project_id" {
+  default = "hello-world"
+}
+
+variable "instance_type" {
+  default = "t2.micro"
+}
+
+variable "private_key_path" {}
+variable "public_key" {}

--- a/modules/ec2-classic/provision/app/index.js
+++ b/modules/ec2-classic/provision/app/index.js
@@ -1,0 +1,8 @@
+const express = require('express');
+
+const app = express();
+
+app.get('/', (req, res) => {
+  res.send(`<h1>Dummy app</h1><p>Response from PID: ${process.pid}. Hit F5 many times!</p>`);
+});
+app.listen(3000, () => console.log('Listening on port 3000!'));

--- a/modules/ec2-classic/provision/app/package.json
+++ b/modules/ec2-classic/provision/app/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "sample-app",
+  "version": "0.0.1",
+  "main": "index.js",
+  "author": {
+    "name": "Julian Reyes",
+    "email": "jreyes@bixlabs.com",
+    "url": "https://twitter.com/rokemaster"
+  },
+  "dependencies": {
+    "express": "^4.15.4"
+  },
+  "private": true
+}

--- a/modules/ec2-classic/provision/install_dummy_app.sh
+++ b/modules/ec2-classic/provision/install_dummy_app.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# This loads nvm
+export NVM_DIR="$HOME/.nvm"
+\. "$NVM_DIR/nvm.sh"
+
+cp -r $HOME/provision/app $HOME/
+cp -r $HOME/provision/pm2.json $HOME/app-pm2.json
+npm i -g pm2
+
+cd $HOME/app
+npm i
+
+pm2 start $HOME/app-pm2.json

--- a/modules/ec2-classic/provision/install_nginx.sh
+++ b/modules/ec2-classic/provision/install_nginx.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+export DEBIAN_FRONTEND=noninteractive
+
+sudo apt-get install -y nginx
+sudo rm /etc/nginx/sites-enabled/default
+sudo ln -s $HOME/provision/nginx_app.conf /etc/nginx/sites-enabled/default
+sudo systemctl restart nginx

--- a/modules/ec2-classic/provision/install_nvm.sh
+++ b/modules/ec2-classic/provision/install_nvm.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+function latest_version() {
+    curl -s https://api.github.com/repos/creationix/nvm/releases/latest \
+        | grep 'tag_name' \
+        | cut -d '"' -f 4
+}
+
+function install_version() {
+    curl "https://raw.githubusercontent.com/creationix/nvm/${1}/install.sh" \
+        | bash
+}
+
+install_version `latest_version`
+
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+
+nvm install 8.4.0

--- a/modules/ec2-classic/provision/install_postgres.sh
+++ b/modules/ec2-classic/provision/install_postgres.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -e
+
+DB_NAME=${1}
+
+export DEBIAN_FRONTEND=noninteractive
+
+## Install postgres
+sudo add-apt-repository "deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main"
+wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+sudo apt-get update
+sudo apt-get install -y postgresql-9.6
+
+## Setup postgres
+sudo sed -i.bak -e 's/peer/trust/' /etc/postgresql/9.6/main/pg_hba.conf
+sudo systemctl restart postgresql
+echo "ALTER USER postgres WITH PASSWORD 'postgres';" | psql -U postgres
+
+## Setup database
+echo "CREATE DATABASE hey_mozo ${DB_NAME};" | psql -U postgres

--- a/modules/ec2-classic/provision/install_ubuntu_build_essential.sh
+++ b/modules/ec2-classic/provision/install_ubuntu_build_essential.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e
+export DEBIAN_FRONTEND=noninteractive
+
+sudo apt-get update
+sudo apt-get install -y build-essential libssl-dev

--- a/modules/ec2-classic/provision/nginx_app.conf
+++ b/modules/ec2-classic/provision/nginx_app.conf
@@ -1,0 +1,18 @@
+upstream app {
+    server 127.0.0.1:3000;
+}
+
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+
+    server_name _;
+
+    location / {
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+        proxy_pass http://app;
+    }
+}

--- a/modules/ec2-classic/provision/pm2.json
+++ b/modules/ec2-classic/provision/pm2.json
@@ -1,0 +1,10 @@
+{
+  "name": "dummy-app",
+  "cwd": "/home/ubuntu/app",
+  "script": "index.js",
+  "env": {
+    "NODE_ENV": "production"
+  },
+  "instances": 2,
+  "exec_mode": "cluster"
+}

--- a/modules/ec2-classic/security_group.tf
+++ b/modules/ec2-classic/security_group.tf
@@ -1,0 +1,39 @@
+resource "aws_security_group" "node_nginx" {
+  name = "${var.project_id}-node-nginx"
+  description = "Machine with Nginx and Node"
+  vpc_id = "${aws_vpc.selected.id}"
+
+  egress {
+    from_port = 0
+    to_port = 0
+    protocol = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group_rule" "node_nginx_http" {
+  from_port = 80
+  protocol = "tcp"
+  security_group_id = "${aws_security_group.node_nginx.id}"
+  to_port = 80
+  type = "ingress"
+  cidr_blocks = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "node_nginx_ssh" {
+  from_port = 22
+  protocol = "tcp"
+  security_group_id = "${aws_security_group.node_nginx.id}"
+  to_port = 22
+  type = "ingress"
+  cidr_blocks = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "node_nginx_https" {
+  from_port = 443
+  protocol = "tcp"
+  security_group_id = "${aws_security_group.node_nginx.id}"
+  to_port = 443
+  type = "ingress"
+  cidr_blocks = ["0.0.0.0/0"]
+}

--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,45 @@ output "my_project.public_dns" {
 }
 ```
 
-then `terraform init`, `terraform get`, `terraform plan` and `terraform apply` and you are good to go.
+then `terraform get`, `terraform init`, `terraform plan` and `terraform apply` and you are good to go.
+
+## `modules/ec2-classic`
+You can use this module if your AWS account is a EC2-classic account, check [here](https://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/default-vpc.html)
+
+So what does this module do? In case you want to create everything from scratch in a EC2-Classic AWS account you can use this module.
+Here is a list of what this module is doing for you:
+                             
+  * We create a VPC
+  * We create a Route Table rule for the VPC in the default Route table of that VPC
+  * Create an Internet Gateway and associate it with the VPC we just created.
+  * Create a subnet and associate it with the VPC.
+  * Associate the Security Group that we are creating with the VPC we just created, all of this is to be able to have "egress" rules in the Security Group.
+ 
+### How to use
+
+> **Note** Before continue you need to [install terraform][1] and also have configured an [aws named profile][2]
+
+Define your resource, remember some ssh key pair should be create before
+
+```
+module "my_project" {
+  source = "github.com/bixlabs/aws-provisioner/modules/ec2"
+  project_id = "my_project"
+  project_name = "Awesome project"
+  region = "us-east-1"
+  profile = "my_aws_profile"
+
+  private_key_path = "~/.ssh/my-ec2-amazon-pair.pem"
+  public_key = "ssh-rsa AAAAB3NzaC1yc2E... "
+}
+
+output "my_project.public_dns" {
+  value = "${module.my_project.nginx_node.public_dns}"
+}
+```
+
+then `terraform get`, `terraform init`, `terraform plan` and `terraform apply` and you are good to go.
+
 
 ## `modules/ec2-postgresql`
 it will create a ubuntu 16.04 with all from `modules/ec2` plus


### PR DESCRIPTION
Hi Guys,

For getting context about the EC2-classic problem check [this](https://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/default-vpc.html) out.

Also you can see the problem in this [issue](https://github.com/hashicorp/terraform/issues/4367) too, I'll put a reference of this solution in the issue because it might help a lot people in the future.

So what we are doing here (In case you want to create everything from scratch in a EC2-Classic AWS accoun)t:

* We create a VPC
* We create a Route Table rule for the VPC in the default Route table of that VPC
* Create an Internet Gateway and associate it with the VPC we just created.
* Create a subnet and associate it with the VPC.
* Associate the Security Group that we are creating with the VPC we just created, all of this is to be able to have "egress" rules in the Security Group.

TODO: https://github.com/bixlabs/aws-provisioner/issues/3

Thanks!

